### PR TITLE
127 - create register page

### DIFF
--- a/src/app/_core/services/form-utils.service.spec.ts
+++ b/src/app/_core/services/form-utils.service.spec.ts
@@ -1,0 +1,172 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FormUtilsService } from './form-utils.service';
+import {
+  AbstractControl,
+  FormControl,
+  FormGroup,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { LoginForm } from '../models/forms.model';
+
+describe('FormUtilsService', () => {
+  let service: FormUtilsService;
+  let form: FormGroup<{
+    email: FormControl<string>;
+    password: FormControl<string>;
+  }>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FormUtilsService);
+    form = new FormGroup({
+      email: new FormControl('', {
+        nonNullable: true,
+        validators: [Validators.required, Validators.email],
+      }),
+      password: new FormControl('', {
+        nonNullable: true,
+        validators: [Validators.required, Validators.minLength(8)],
+      }),
+    });
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('isFieldInError', () => {
+    it('should return true if email is invalid and dirty', () => {
+      const control = form.controls.email;
+      control.setValue('');
+      control.markAsDirty();
+      expect(service.isFieldInError<LoginForm>(form, 'email')).toBeTrue();
+    });
+    it('should return true if password is invalid and touched', () => {
+      const control = form.controls.password;
+      control.setValue('');
+      control.markAsTouched();
+      expect(service.isFieldInError<LoginForm>(form, 'password')).toBeTrue();
+    });
+
+    it('should return true if email is invalid and isSubmitted', () => {
+      const control = form.controls.email;
+      control.setValue('');
+      expect(service.isFieldInError<LoginForm>(form, 'email', true)).toBeTrue();
+    });
+
+    it('should return false if field is valid', () => {
+      const control = form.controls.email;
+      control.setValue('test@email.com');
+      control.markAsDirty();
+      expect(service.isFieldInError<LoginForm>(form, 'email')).toBeFalse();
+    });
+
+    it('should return false for unknown field', () => {
+      expect(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        service.isFieldInError<LoginForm>(form, 'unknown' as any)
+      ).toBeFalse();
+    });
+  });
+  describe('getStandardErrorMessage', () => {
+    it('should return required error', () => {
+      const control = new FormControl('', {
+        nonNullable: true,
+        validators: [Validators.required],
+      });
+      control.markAsTouched();
+      expect(service.getStandardErrorMessage(control)).toContain(
+        'Ce champ est requis'
+      );
+    });
+
+    it('should return email error', () => {
+      const control = new FormControl('not-an-email', {
+        nonNullable: true,
+        validators: [Validators.email],
+      });
+      control.markAsTouched();
+      expect(service.getStandardErrorMessage(control)).toContain(
+        "Format d'email invalide"
+      );
+    });
+
+    it('should return minlength error', () => {
+      const control = new FormControl('abc', {
+        nonNullable: true,
+        validators: [Validators.minLength(6)],
+      });
+      control.markAsTouched();
+      expect(service.getStandardErrorMessage(control)).toContain(
+        'Au moins 6 caractères'
+      );
+    });
+
+    it('should return maxlength error', () => {
+      const control = new FormControl('abcdefghi', {
+        nonNullable: true,
+        validators: [Validators.maxLength(5)],
+      });
+      control.markAsTouched();
+      expect(service.getStandardErrorMessage(control)).toContain(
+        'Au maximum 5 caractères'
+      );
+    });
+
+    it('should return mismatch error', () => {
+      // On utilise AbstractControl pour setter l'erreur
+      const control: AbstractControl = new FormControl('');
+      control.setErrors({ mismatch: true } as ValidationErrors);
+      expect(service.getStandardErrorMessage(control)).toContain(
+        'Les champs ne correspondent pas'
+      );
+    });
+
+    it('should return empty string for valid control', () => {
+      const control = new FormControl('validValue');
+      expect(service.getStandardErrorMessage(control)).toBe('');
+    });
+  });
+
+  describe('getEmailError', () => {
+    it('should return required error', () => {
+      const control = new FormControl('', {
+        nonNullable: true,
+        validators: [Validators.required],
+      });
+      control.markAsTouched();
+      expect(service.getEmailError(control)).toContain('obligatoire');
+    });
+
+    it('should return invalid email error', () => {
+      const control = new FormControl('test', {
+        nonNullable: true,
+        validators: [Validators.email],
+      });
+      control.markAsTouched();
+      expect(service.getEmailError(control)).toContain('format');
+    });
+  });
+
+  describe('getPasswordError', () => {
+    it('should return required error', () => {
+      const control = new FormControl('', {
+        nonNullable: true,
+        validators: [Validators.required],
+      });
+      control.markAsTouched();
+      expect(service.getPasswordError(control)).toContain('obligatoire');
+    });
+
+    it('should return minlength error with correct min', () => {
+      const control = new FormControl('123', {
+        nonNullable: true,
+        validators: [Validators.minLength(8)],
+      });
+      control.markAsTouched();
+      expect(service.getPasswordError(control)).toContain('8 caractères');
+    });
+  });
+});

--- a/src/app/_core/services/form-utils.service.ts
+++ b/src/app/_core/services/form-utils.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+import { AbstractControl, FormControl, FormGroup } from '@angular/forms';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FormUtilsService {
+  isFieldInError<T extends object>(
+    /**
+     * Détecte si un champ est en erreur dans un FormGroup typé
+     */
+    form: FormGroup<{ [K in keyof T]: FormControl<T[K]> }>,
+    field: keyof T,
+    isSubmitted = false
+  ): boolean {
+    const control = form.get(field as string);
+    if (!control) return false;
+    return control.invalid && (control.dirty || control.touched || isSubmitted);
+  }
+  /**
+   * Message d'erreur générique pour n'importe quel champ
+   */
+  getStandardErrorMessage(control: AbstractControl): string {
+    if (!control || !control.errors) return '';
+    if (control.hasError('required')) return 'Ce champ est requis';
+    if (control.hasError('email')) return "Format d'email invalide";
+    if (control.hasError('minlength')) {
+      const min = control.getError('minlength')?.requiredLength;
+      return `Au moins ${min} caractères`;
+    }
+    if (control.hasError('maxlength')) {
+      const max = control.getError('maxlength')?.requiredLength;
+      return `Au maximum ${max} caractères`;
+    }
+    if (control.hasError('mismatch')) return 'Les champs ne correspondent pas';
+    return 'Champ invalide';
+  }
+
+  getPasswordError(control: AbstractControl): string {
+    if (!control || !control.errors) return '';
+    if (control.hasError('required')) return 'Le mot de passe est obligatoire';
+    if (control.hasError('minlength')) {
+      const min = control.getError('minlength')?.requiredLength;
+      return `Le mot de passe doit contenir au moins ${min} caractères`;
+    }
+    return this.getStandardErrorMessage(control);
+  }
+
+  getEmailError(control: AbstractControl): string {
+    if (!control || !control.errors) return '';
+    if (control.hasError('required')) return "L'email est obligatoire";
+    if (control.hasError('email')) return "Le format d'email est invalide";
+    return this.getStandardErrorMessage(control);
+  }
+}

--- a/src/app/shared/forms/login-form/login-form.component.spec.ts
+++ b/src/app/shared/forms/login-form/login-form.component.spec.ts
@@ -50,8 +50,10 @@ describe('LoginFormComponent', () => {
       const passwordHelper = fixture.nativeElement.querySelector(
         '[data-test="helper-password-input"]'
       );
-      expect(emailHelper.textContent).toContain('Email is required');
-      expect(passwordHelper.textContent).toContain('Password is required');
+      expect(emailHelper.textContent).toContain("L'email est obligatoire");
+      expect(passwordHelper.textContent).toContain(
+        'Le mot de passe est obligatoire'
+      );
     });
 
     it('should show invalid email error for bad format', () => {
@@ -62,7 +64,9 @@ describe('LoginFormComponent', () => {
       const emailHelper = fixture.nativeElement.querySelector(
         '[data-test="helper-email-input"]'
       );
-      expect(emailHelper.textContent).toContain('Invalid email address');
+      expect(emailHelper.textContent).toContain(
+        "Le format d'email est invalide"
+      );
     });
 
     it('should show minlength error for short password', () => {
@@ -74,13 +78,13 @@ describe('LoginFormComponent', () => {
         '[data-test="helper-password-input"]'
       );
       expect(passwordHelper.textContent).toContain(
-        'Password must be at least 6 characters long'
+        'Le mot de passe doit contenir au moins 12 caractères'
       );
     });
 
     it('should have no error message with valid fields', () => {
       component.loginForm.controls['email'].setValue('john@mail.com');
-      component.loginForm.controls['password'].setValue('123456');
+      component.loginForm.controls['password'].setValue('123456789111');
       component.loginForm.markAllAsTouched();
       fixture.detectChanges();
 

--- a/src/app/shared/forms/login-form/login-form.component.ts
+++ b/src/app/shared/forms/login-form/login-form.component.ts
@@ -1,6 +1,5 @@
 import { Component, inject } from '@angular/core';
 import {
-  AbstractControl,
   FormBuilder,
   FormGroup,
   ReactiveFormsModule,
@@ -10,6 +9,7 @@ import { InputComponent } from '../../ui/input/input.component';
 import { IconComponent } from '../../ui/icon/icon.component';
 import { LoginForm } from '../../../_core/models/forms.model';
 import { ButtonComponent } from '../../ui/button/button.component';
+import { FormUtilsService } from '../../../_core/services/form-utils.service';
 
 @Component({
   selector: 'app-login-form',
@@ -24,49 +24,34 @@ import { ButtonComponent } from '../../ui/button/button.component';
 })
 export class LoginFormComponent {
   private formBuilder: FormBuilder = inject(FormBuilder);
-
+  private formUtils = inject(FormUtilsService);
   public isSubmitted = false;
   loginForm: FormGroup = this.formBuilder.group({
     email: ['', [Validators.required, Validators.email]],
-    password: ['', [Validators.required, Validators.minLength(6)]],
+    password: ['', [Validators.required, Validators.minLength(12)]],
   });
 
-  //méthodes
   isFieldInError(field: keyof LoginForm): boolean {
-    const control = this.loginForm.controls[field];
-    if (control.invalid && control.dirty) return true;
-    if (control.invalid && control.touched) return true;
-    if (control.invalid && this.isSubmitted) return true;
-    return false;
-  }
-
-  getEmailError(field: AbstractControl): string {
-    if (field.errors?.['required']) return 'Email is required';
-    if (field.errors?.['email']) return 'Invalid email address';
-    return '';
-  }
-
-  getPasswordError(field: AbstractControl): string {
-    if (field.errors?.['required']) return 'Password is required';
-    if (field.errors?.['minlength'])
-      return 'Password must be at least 6 characters long';
-    return '';
+    return this.formUtils.isFieldInError<LoginForm>(
+      this.loginForm,
+      field,
+      this.isSubmitted
+    );
   }
 
   handleFieldErrors(fieldName: keyof LoginForm): string {
     const field = this.loginForm.controls[fieldName];
-    if (this.isFieldInError(fieldName)) {
-      switch (fieldName) {
-        case 'email':
-          return this.getEmailError(field);
-        case 'password':
-          return this.getPasswordError(field);
-        // Ajoutez d'autres champs ici si nécessaire
-        default:
-          return '';
-      }
+    if (!this.isFieldInError(fieldName)) return '';
+
+    switch (fieldName) {
+      case 'email':
+        return this.formUtils.getEmailError(field);
+      case 'password':
+        return this.formUtils.getPasswordError(field);
+      // Ajoutez d'autres champs ici si nécessaire
+      default:
+        return this.formUtils.getStandardErrorMessage(field);
     }
-    return '';
   }
 
   onSubmit() {


### PR DESCRIPTION
service to handle if form field is in error and handle some error message

# Checklist

- [X] run `npm run test` or `mvn test`
- [X] les messages de commit et le nom de la pull request suivent les [Guidelines](https://github.com/Pecunia-App/.github/tree/main/profile#guidelines)

## [<127>](https://tree.taiga.io/project/lenny-zanotelli-pecunia/us/127?milestone=465033)

- création d'un service formUtils pour mutualiser la gestion des erreurs
