### PR TITLE
208 - (authService): add tests with mocked data to simulate Http requests

### DIFF
--- a/src/app/_core/services/auth/auth.mock.ts
+++ b/src/app/_core/services/auth/auth.mock.ts
@@ -1,0 +1,30 @@
+import { Credentials } from '../../models/forms.model';
+
+export const MOCK_USER_VALID: Credentials = {
+  email: 'user@pecunia.fr',
+  password: 'Password123!',
+};
+
+export const MOCK_USER_INVALID: Credentials = {
+  email: 'testpecunia.fr',
+  password: 'password',
+};
+
+//date expiration 20/09/2120
+export const MOCK_JWT_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHBlY3VuaWEuZnIiLCJyb2xlcyI6W3siYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn1dLCJpYXQiOjE3NTYzMDAwMDAsImV4cCI6NDc1NjMwMDAwMH0.AD-q0bWtfK1uilT7lWRI59KdfVxBI59f3ND0iPhv_lA';
+
+export const MOCK_JWT_TOKEN_EXPIRED =
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHBlY3VuaWEuZnIiLCJyb2xlcyI6W3siYXV0aG9yaXR5IjoiUk9MRV9VU0VSIn1dLCJpYXQiOjE2MDAwMDAwMDAsImV4cCI6MTYwMDAwMDAwMH0.7k3M0zXSt-UYYj0wLbMXUvYuEtQmdX3EIT0JLMugBAY';
+
+export const MOCK_AUTH_ERROR_401 = {
+  status: 401,
+  statusText: 'Unauthorized',
+  error: { message: 'Email ou mot de passe incorrect' },
+};
+
+export const MOCK_AUTH_ERROR_500 = {
+  status: 500,
+  statusText: 'Internal Server Error',
+  error: { message: 'Erreur inconnue' },
+};

--- a/src/app/_core/services/auth/auth.service.spec.ts
+++ b/src/app/_core/services/auth/auth.service.spec.ts
@@ -5,28 +5,30 @@ import {
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import { provideHttpClient, withFetch } from '@angular/common/http';
-// import { environment } from '../../../../environments/environment';
+import {
+  MOCK_AUTH_ERROR_401,
+  MOCK_AUTH_ERROR_500,
+  MOCK_JWT_TOKEN,
+  MOCK_JWT_TOKEN_EXPIRED,
+  MOCK_USER_INVALID,
+  MOCK_USER_VALID,
+} from './auth.mock';
+import { environment } from '../../../../environments/environment';
 
 describe('AuthService', () => {
   let service: AuthService;
   let httpMock: HttpTestingController;
-  // const apiUrl = environment.apiUrl;
-  // const credentials = {
-  //   email: 'test@pecunia.fr',
-  //   password: environment.testPassword,
-  // };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         AuthService,
-        provideHttpClientTesting(),
         provideHttpClient(withFetch()),
+        provideHttpClientTesting(),
       ],
     });
     service = TestBed.inject(AuthService);
     httpMock = TestBed.inject(HttpTestingController);
-    service.clearToken();
   });
 
   afterEach(() => {
@@ -34,23 +36,120 @@ describe('AuthService', () => {
     localStorage.clear();
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  it('TC01 - should store token on successful login', () => {
+    //1) déclenchement req (observable)
+    service.login(MOCK_USER_VALID).subscribe(() => {
+      //4) vérification après avoir reçu la réponse simulé (async)
+      expect(localStorage.getItem('pecunia-token')).toBe(MOCK_JWT_TOKEN);
+      expect(service.isLoggedIn()).toBeTrue();
+    });
+
+    //2) interception et simulation requete HTTP avec HttpTestingController
+    const reqMocked = httpMock.expectOne(`${environment.apiUrl}/auth/login`);
+
+    expect(reqMocked.request.method).toBe('POST');
+    expect(reqMocked.request.body).toEqual(MOCK_USER_VALID);
+    //3) méthode flush simule la réponse et cela déclenche le subscribe de l'observable
+    reqMocked.flush(MOCK_JWT_TOKEN);
   });
 
-  // it('should login and store token', (done) => {
-  //   console.log('Test credentials:', credentials);
+  it('TC02 - should handle 401 error on invalid credentials', () => {
+    service.login(MOCK_USER_INVALID).subscribe({
+      error: (error) => {
+        const parsed = JSON.parse(error.error);
+        expect(error.status).toBe(MOCK_AUTH_ERROR_401.status);
+        expect(error.statusText).toBe(MOCK_AUTH_ERROR_401.statusText);
+        expect(parsed.message).toBe(MOCK_AUTH_ERROR_401.error.message);
+      },
+    });
 
-  //   service.login(credentials).subscribe({
-  //     next: (token) => {
-  //       expect(token).toBeTruthy();
-  //       expect(service.getToken()).toBe(token);
-  //       done();
-  //     },
-  //     error: (err) => {
-  //       fail(`Erreur login: ${JSON.stringify(err)}`);
-  //       done();
-  //     },
-  //   });
-  // });
+    const req = httpMock.expectOne(`${environment.apiUrl}/auth/login`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(MOCK_USER_INVALID);
+
+    req.flush(
+      { message: 'Email ou mot de passe incorrect' },
+      {
+        status: 401,
+        statusText: 'Unauthorized',
+      }
+    );
+  });
+
+  it('TC03 - should handle 500 server error on login', () => {
+    service.login(MOCK_USER_VALID).subscribe({
+      next: () => fail('Should have failed with 500 error'),
+      error: (error) => {
+        const parsed = JSON.parse(error.error);
+        expect(error.status).toBe(MOCK_AUTH_ERROR_500.status);
+        expect(error.statusText).toBe(MOCK_AUTH_ERROR_500.statusText);
+        expect(parsed.message).toBe(MOCK_AUTH_ERROR_500.error.message);
+      },
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/auth/login`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(MOCK_USER_VALID);
+
+    req.flush(
+      { message: 'Erreur inconnue' },
+      {
+        status: 500,
+        statusText: 'Internal Server Error',
+      }
+    );
+  });
+
+  it('TC04 - should store token in localStorage and signal', () => {
+    service.saveToken(MOCK_JWT_TOKEN);
+    expect(localStorage.getItem('pecunia-token')).toBe(MOCK_JWT_TOKEN);
+    expect(service.getToken()).toBe(MOCK_JWT_TOKEN);
+  });
+
+  it('TC05 - isLoggedIn should return true if token is valid (not expired)', () => {
+    service.saveToken(MOCK_JWT_TOKEN);
+    expect(service.isLoggedIn()).toBeTrue();
+  });
+
+  it('TC06 - isLoggedIn should return false if token has an expired date', () => {
+    service.saveToken(MOCK_JWT_TOKEN_EXPIRED);
+    expect(service.isLoggedIn()).toBeFalse();
+  });
+  it('TC06 - isLoggedIn should return false if no token stored', () => {
+    service.clearToken();
+    expect(service.isLoggedIn()).toBeFalse();
+  });
+
+  it('TC07 - should return user role from token', () => {
+    service.saveToken(MOCK_JWT_TOKEN);
+    expect(service.userRole()).toBe('ROLE_USER');
+  });
+
+  it('TC08 - should remove token from localStorage and signal', () => {
+    //Simule un token stocké
+    service.saveToken(MOCK_JWT_TOKEN);
+
+    //Vérifie qu’il est bien présent avant suppression
+    expect(localStorage.getItem('pecunia-token')).toBe(MOCK_JWT_TOKEN);
+    expect(service.getToken()).toBe(MOCK_JWT_TOKEN);
+
+    //Appelle la méthode à tester
+    service.clearToken();
+
+    //Vérifie qu’il est supprimé du localStorage et du signal
+    expect(localStorage.getItem('pecunia-token')).toBeNull();
+    expect(service.getToken()).toBeNull();
+  });
+
+  it('TC09 - should clear token if expired (verifyToken)', () => {
+    service.saveToken(MOCK_JWT_TOKEN_EXPIRED);
+
+    expect(localStorage.getItem('pecunia-token')).toBe(MOCK_JWT_TOKEN_EXPIRED);
+    expect(service.getToken()).toBe(MOCK_JWT_TOKEN_EXPIRED);
+
+    service.verifyToken();
+
+    expect(localStorage.getItem('pecunia-token')).toBeNull();
+    expect(service.getToken()).toBeNull();
+  });
 });

--- a/src/app/_core/services/auth/auth.service.ts
+++ b/src/app/_core/services/auth/auth.service.ts
@@ -16,7 +16,7 @@ export class AuthService {
   private _token = signal<string | null>(localStorage.getItem('pecunia-token'));
 
   // 2. Signal computed pour savoir si l'utilisateur est connecté
-  readonly isLoggedIn = computed(() => {
+  readonly isLoggedIn = computed<boolean>(() => {
     const value = this._token();
     if (!value) return false;
 
@@ -32,7 +32,7 @@ export class AuthService {
     }
   });
   // 3. Signal computed pour récupérer le rôle
-  readonly userRole = computed(() => {
+  readonly userRole = computed<string | null>(() => {
     const value = this._token();
     if (!value) return null;
 


### PR DESCRIPTION
# Checklist

- [x] run `npm run test` or `mvn test`
- [x] les messages de commit et le nom de la pull request suivent les [Guidelines](https://github.com/Pecunia-App/.github/tree/main/profile#guidelines)

## [<208>](https://tree.taiga.io/project/lenny-zanotelli-pecunia/task/208)

"description technique de ce que vous avez fait en bullet point"

ajout séries de tests avec données mockées pour simuler les appels HTTP 

les tests suivent le plan suivant: 

<img width="1056" height="395" alt="image" src="https://github.com/user-attachments/assets/45a9fd8a-c0d4-492e-bf45-771104ed3f28" />

