### PR TITLE
fix(transactions,layout): correct pagination handling, mock data, and layout padding

### DIFF
--- a/src/app/_core/mocks/mock-transactions.ts
+++ b/src/app/_core/mocks/mock-transactions.ts
@@ -6,14 +6,7 @@ import { MOCK_TAGS } from './mock-tags';
 
 const EUR = (amount: number): MoneyDTO => ({
   amount,
-  currency: {
-    currencyCode: 'EUR',
-    displayName: 'Euro',
-    symbol: '€',
-    defaultFractionDigits: 2,
-    numericCode: 978,
-    numericCodeAsString: '978',
-  },
+  currency: 'EUR',
   currencySymbol: '€',
   currencyCode: 'EUR',
 });

--- a/src/app/_core/models/transactions/money.dto.ts
+++ b/src/app/_core/models/transactions/money.dto.ts
@@ -1,8 +1,6 @@
-import { CurrencyDTO } from './currency.dto';
-
 export interface MoneyDTO {
   amount: number;
-  currency: CurrencyDTO;
+  currency: string;
   currencySymbol: string;
   currencyCode: string;
 }

--- a/src/app/_core/services/transactions/transactions.api.service.ts
+++ b/src/app/_core/services/transactions/transactions.api.service.ts
@@ -11,16 +11,26 @@ import { environment } from '../../../../environments/environment';
 @Injectable({ providedIn: 'root' })
 export class TransactionsApiService implements TransactionsDataSource {
   private static readonly API_URL = `${environment.apiUrl}`;
-  private baseUrl = `${TransactionsApiService.API_URL}/transactions`;
+  private baseUrl = `${TransactionsApiService.API_URL}`;
   private readonly http = inject(HttpClient);
 
   /**
    * Récupère toutes les transactions d'un wallet.
    * GET /wallets/{walletId}/transactions
    */
-  getTransactions(walletId: number): Observable<TransactionResponse> {
+  getTransactions(
+    walletId: number,
+    page = 0,
+    size = 20
+  ): Observable<TransactionResponse> {
+    const params = {
+      page: page.toString(),
+      size: size.toString(),
+      sort: 'createdAt,desc',
+    };
     return this.http.get<TransactionResponse>(
-      `${this.baseUrl}/wallets/${walletId}/transactions`
+      `${this.baseUrl}/wallets/${walletId}/transactions`,
+      { params }
     );
   }
 

--- a/src/app/_core/services/transactions/transactions.data-source.ts
+++ b/src/app/_core/services/transactions/transactions.data-source.ts
@@ -14,7 +14,11 @@ export interface TransactionResponse {
 }
 
 export interface TransactionsDataSource {
-  getTransactions(walletId: number): Observable<TransactionResponse>;
+  getTransactions(
+    walletId: number,
+    page?: number,
+    size?: number
+  ): Observable<TransactionResponse>;
   getTransactionById(id: number): Observable<TransactionDTO>;
   // + create/update/delete plus tard
 }

--- a/src/app/_core/services/transactions/transactions.mock.service.ts
+++ b/src/app/_core/services/transactions/transactions.mock.service.ts
@@ -8,10 +8,26 @@ import { MOCK_TRANSACTIONS_RESPONSE } from '../../mocks/mock-transactions';
 
 @Injectable({ providedIn: 'root' })
 export class TransactionsMockService implements TransactionsDataSource {
-  getTransactions(): Observable<TransactionResponse> {
-    return of(MOCK_TRANSACTIONS_RESPONSE);
-  }
+  getTransactions(
+    walletId: number,
+    page = 0,
+    size = 5
+  ): Observable<TransactionResponse> {
+    const all = MOCK_TRANSACTIONS_RESPONSE.content;
+    const start = page * size;
+    const end = start + size;
+    const paginated = all.slice(start, end);
 
+    return of({
+      content: paginated,
+      page: {
+        size,
+        number: page,
+        totalElements: all.length,
+        totalPages: Math.ceil(all.length / size),
+      },
+    });
+  }
   getTransactionById(id: number) {
     const found = MOCK_TRANSACTIONS_RESPONSE.content.find((t) => t.id === id)!;
     return of(found);

--- a/src/app/_core/services/transactions/transactions.service.ts
+++ b/src/app/_core/services/transactions/transactions.service.ts
@@ -12,19 +12,21 @@ export class TransactionsService implements TransactionsDataSource {
   private impl: TransactionsDataSource;
 
   constructor(mock: TransactionsMockService, api: TransactionsApiService) {
-    // 🔧 Basculer ici selon .env
+    // Basculer ici selon .env
     this.impl = environment.useMocks ? mock : api;
   }
 
-  getTransactions(walletId: number): Observable<TransactionResponse> {
-    return this.impl.getTransactions(walletId);
+  getTransactions(
+    walletId: number,
+    page?: number,
+    size?: number
+  ): Observable<TransactionResponse> {
+    return this.impl.getTransactions(walletId, page, size);
   }
 
   getTransactionById(id: number): Observable<TransactionDTO> {
     return this.impl.getTransactionById(id);
   }
-
-  // Tu ajouteras ici plus tard :
   // create(walletId: number, dto: TransactionDTO)
   // update(id: number, dto: TransactionDTO)
   // delete(id: number)

--- a/src/app/shared/layout/connected-layout/connected-layout.component.scss
+++ b/src/app/shared/layout/connected-layout/connected-layout.component.scss
@@ -26,5 +26,5 @@
 }
 
 .connected-content {
-  @include layout.padding(space-64, 0, 0, 0);
+  @include layout.padding(space-64, 0);
 }

--- a/src/app/shared/navigation/menu-header/menu-header.component.scss
+++ b/src/app/shared/navigation/menu-header/menu-header.component.scss
@@ -4,6 +4,7 @@
 .menu-desk-wrapper {
   position: fixed;
   width: 100%;
+  min-height: 64px;
   text-align: center;
   border: solid 1px transparent;
   @include layout.padding(space-10, space-12);
@@ -19,6 +20,31 @@
   top: 0;
 
   @include layout.flex($dir: row, $justify: space-between);
+
+  @media (min-width: 1440px) {
+    .menu-logo {
+      position: absolute;
+      left: 2rem;
+      top: 50%;
+      transform: translateY(-50%);
+      height: 40px;
+      display: flex;
+      align-items: center;
+    }
+
+    .menu-links {
+      justify-content: center;
+      align-items: center;
+      flex: 1 1 auto;
+    }
+
+    app-menu-header-dropdown {
+      position: absolute;
+      right: 12px;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+  }
 }
 
 .menu-links {

--- a/src/app/shared/transactions/transaction-card/transaction-card.component.ts
+++ b/src/app/shared/transactions/transaction-card/transaction-card.component.ts
@@ -30,7 +30,7 @@ export class TransactionCardComponent {
     const formatted = absValue.toLocaleString('fr-FR', {
       minimumFractionDigits: 2,
     });
-    return `${formatted} ${this.transaction.amount.currencyCode}`;
+    return `${formatted} ${this.transaction.amount.currency}`;
   }
 
   hasProvider(): boolean {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -2,5 +2,5 @@ export const environment = {
   production: false,
   apiUrl: import.meta.env.NG_APP_API_URL,
   testPassword: 'Password123!',
-  useMocks: true,
+  useMocks: false,
 };


### PR DESCRIPTION
# Checklist

- [ ] run `npm run test` or `mvn test`
- [ ] les messages de commit et le nom de la pull request suivent les [Guidelines](https://github.com/Pecunia-App/.github/tree/main/profile#guidelines)

## [<Numéro de ticket TAIGA>](url)

"description technique de ce que vous avez fait en bullet point"

- correction alignement menu header en desktop
- correction données mockées et typage pour les currency
- correction des services transactions et interface pour adapter les req http avec la pagination du backend
- transaction-list: correction de la logique de chargement et de la gestion de la pagination => req back faite a chaque changement de page pour récupérer les données
- ajout padding fin de page du layout connected pour voir la fin de la liste quand le menu footer est visible en mobile
- passage a false de la variable d’environnement “useMock” en dev pour tester appel api

données récupérées de mon back en local (j'ai fais des scripts SQL que j'ai partagé dans le discord de notre channel) 

<img width="1389" height="946" alt="image" src="https://github.com/user-attachments/assets/1c2dfeed-0c1f-48a3-a2e0-2df6764eb33e" />

